### PR TITLE
Update Iconify dependency and add .zip to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ lerna-debug.log*
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
+# ZIPFiles
+*.zip
+
 # Runtime data
 pids
 *.pid

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "node-50-templates",
       "version": "1.0.0",
       "dependencies": {
+        "@iconify/json": "^2.2.379",
         "bcryptjs": "^3.0.2",
         "compression": "^1.7.4",
         "cookie-parser": "^1.4.6",
@@ -26,7 +27,6 @@
         "socket.io": "^4.7.5"
       },
       "devDependencies": {
-        "@iconify-json/material-symbols": "^1.2.32",
         "@unocss/postcss": "^66.4.2",
         "@unocss/preset-icons": "^66.4.2",
         "npm-run-all": "^4.1.5",
@@ -239,21 +239,26 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
-    "node_modules/@iconify-json/material-symbols": {
-      "version": "1.2.32",
-      "resolved": "https://registry.npmjs.org/@iconify-json/material-symbols/-/material-symbols-1.2.32.tgz",
-      "integrity": "sha512-Jw3wdiNV8X1MoiS0rFzlZFYek/yYS1GTh/64L3lZkqlPo+uJAb0xdtVWZR54tzY/0G2OuWXMDqeCCQ6I2wB9/w==",
-      "dev": true,
-      "license": "Apache-2.0",
+    "node_modules/@iconify/json": {
+      "version": "2.2.379",
+      "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.379.tgz",
+      "integrity": "sha512-PInpWLQi2C+fDIbBdVNcKOj9QKl7TT6sXqFqYMa4e34sMx206PiUlg0puWgo1Q1C/TDNQiy/raGWUbssOb1eyg==",
+      "license": "MIT",
       "dependencies": {
-        "@iconify/types": "*"
+        "@iconify/types": "*",
+        "pathe": "^1.1.2"
       }
+    },
+    "node_modules/@iconify/json/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dev": "npm-run-all --parallel build:css dev:css start"
   },
   "dependencies": {
+    "@iconify/json": "^2.2.379",
+    "bcryptjs": "^3.0.2",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
@@ -24,11 +26,9 @@
     "multer": "^1.4.5-lts.1",
     "node-cron": "^3.0.3",
     "prom-client": "^15.1.3",
-    "socket.io": "^4.7.5",
-    "bcryptjs": "^3.0.2"
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
-    "@iconify-json/material-symbols": "^1.2.32",
     "@unocss/postcss": "^66.4.2",
     "@unocss/preset-icons": "^66.4.2",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Commit Message:
Refactor: Update icon dependencies and gitignore rules.

Replaced `@iconify-json/material-symbols` (dev dependency) with `@iconify/json` (production dependency) for broader icon support. Added `*.zip` to `.gitignore` to prevent committing compiled archives.

This PR was generated automatically using Gemini.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates: added @iconify/json (^2.2.379) and bcryptjs (^3.0.2); removed dev dependency @iconify-json/material-symbols; minor reordering of dependency entries.
  * Repository housekeeping: .gitignore now excludes .zip files to prevent accidental commits.
  * Formatting: adjusted trailing newline in package.json (no functional impact).
  * No user-facing functionality changes; runtime behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->