### PR TITLE
Display last 10 commits in `repo_status`

### DIFF
--- a/refresh.py
+++ b/refresh.py
@@ -129,17 +129,27 @@ def refresh_repo(branch):
 
 
 def repo_status():
-    branch = run_command("git rev-parse --abbrev-ref HEAD", capture=True) or "?"
-    latest_commit = run_command("git log -1 --pretty=%B", capture=True) or "?"
-    author = run_command("git log -1 --pretty=%an", capture=True) or "?"
+    commits = run_command("git log -10 --pretty=format:'%h|%an|%s'", capture=True)
+    if not commits:
+        console.print("[WARN] No commits found")
+        return
+
     table = Table(
-        title="Repository Status", show_header=True, header_style="bold magenta"
+        title="Last 10 Commits", show_header=True, header_style="bold magenta"
     )
-    table.add_column("Branch", style="cyan")
-    table.add_column("Last Commit", style="green")
+    table.add_column("Hash", style="cyan")
     table.add_column("Author", style="yellow")
-    table.add_row(branch, latest_commit, author)
+    table.add_column("Message", style="green")
+
+    for line in commits.splitlines():
+        try:
+            commit_hash, author, message = line.split("|", 2)
+            table.add_row(commit_hash, author, message)
+        except ValueError:
+            continue
+
     console.print(table)
+
 
 
 # ----------------- Backup -----------------


### PR DESCRIPTION
Commit Message:
Feat: Enhance `repo_status` to display last 10 commits.

This update refactors the `repo_status` function to show a table of the last 10 commits, including their hash, author, and message, instead of just the latest commit. This provides a more comprehensive overview of recent repository activity.

This PR was generated automatically using Gemini.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The repository status view now shows the last 10 commits in a multi-row table.
  * Updated table title to “Last 10 Commits” with columns for Hash, Author, and Message.
  * Improved handling for empty repositories: displays a warning and skips table rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->